### PR TITLE
Ensure `lazyLoading` option is always set

### DIFF
--- a/files/routable-files/index.js
+++ b/files/routable-files/index.js
@@ -4,8 +4,8 @@
 const EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
-  name: '<%= dasherizedModuleName %>'<% if (hasLazyFlag) { %>,
+  name: '<%= dasherizedModuleName %>',
   lazyLoading: {
     enabled: <%= isLazy %>
-  }<% } %>
+  }
 });

--- a/files/routeless-files/index.js
+++ b/files/routeless-files/index.js
@@ -4,8 +4,8 @@
 const EngineAddon = require('ember-engines/lib/engine-addon');
 
 module.exports = EngineAddon.extend({
-  name: '<%= dasherizedModuleName %>'<% if (hasLazyFlag) { %>,
+  name: '<%= dasherizedModuleName %>',
   lazyLoading: {
     enabled: <%= isLazy %>
-  }<% } %>
+  }
 });

--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ module.exports = Object.assign({}, Addon, {
 
     return Object.assign(superLocals, {
       engineModulePrefix,
-      hasLazyFlag: typeof options.lazy !== 'undefined',
       isLazy: !!options.lazy,
       welcome: false
     });


### PR DESCRIPTION
Currently newly generated engines produce a deprecation warning due to the `lazyLoading` option not being defined.

This PR resolves that deprecation warning as well as brings this blueprint in-line with the `in-repo-engine` blueprint by always defining the `lazyLoading` option (defaults to false).