### PR TITLE
Add new excludeRoutesFromApplication option

### DIFF
--- a/files/routable-files/index.js
+++ b/files/routable-files/index.js
@@ -6,6 +6,7 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
   name: '<%= dasherizedModuleName %>',
   lazyLoading: {
-    enabled: <%= isLazy %>
+    enabled: <%= isLazy %>,
+    includeRoutesInApplication: <%= includeRoutesInApplication %>
   }
 });

--- a/files/routeless-files/index.js
+++ b/files/routeless-files/index.js
@@ -6,6 +6,7 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
   name: '<%= dasherizedModuleName %>',
   lazyLoading: {
-    enabled: <%= isLazy %>
+    enabled: <%= isLazy %>,
+    includeRoutesInApplication: <%= includeRoutesInApplication %>
   }
 });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ module.exports = Object.assign({}, Addon, {
     return Object.assign(superLocals, {
       engineModulePrefix,
       isLazy: !!options.lazy,
+      includeRoutesInApplication: !options.excludeRoutesFromApplication,
       welcome: false
     });
   },
@@ -43,6 +44,11 @@ module.exports = Object.assign({}, Addon, {
       name: 'lazy',
       type: Boolean,
       description: 'Whether this Engine should load lazily or not'
+    },
+    {
+      name: 'exclude-routes-from-application',
+      type: Boolean,
+      description: 'Whether this Engine should exclude its routes from the applications vendor file or not'
     }
   ],
 


### PR DESCRIPTION
Introduces a new `exclude-routes-from-application` flag so that engines can be generated with the `lazyLoading.includeRoutesInApplication` flag defaulted to `false`.

I can also PR this to the ember-engines repo for the `in-repo-engine` blueprint if needed.

## Usage Example

```
ember new foo-engine -b git@github.com:ember-engines/engine-blueprint.git --lazy --exclude-routes-from-application
```