### PR TITLE
Update ember-engines dep. to v0.8.5

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = Object.assign({}, Addon, {
     contents = JSON.parse(contents)
 
     // Add `ember-engines` to devDependencies by default
-    contents.devDependencies['ember-engines'] = '^0.5.14';
+    contents.devDependencies['ember-engines'] = '^0.8.5';
 
     // Move `ember-cli-htmlbars` into dependencies from devDependencies
     contents.dependencies['ember-cli-htmlbars'] = contents.devDependencies['ember-cli-htmlbars'];


### PR DESCRIPTION
Fixes #20.
Update usage of `ember-engines` to v0.8.5.