### PR TITLE
Don't remove ember-cli-htmlbars from dependencies during generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = Object.assign({}, Addon, {
     contents = JSON.parse(contents)
 
     // Add `ember-engines` to devDependencies by default
-    contents.devDependencies['ember-engines'] = '^0.8.5';
+    contents.devDependencies['ember-engines'] = '^0.8.12';
 
     return stringifyAndNormalize(sortPackageJson(contents));
   },

--- a/index.js
+++ b/index.js
@@ -122,10 +122,6 @@ module.exports = Object.assign({}, Addon, {
     // Add `ember-engines` to devDependencies by default
     contents.devDependencies['ember-engines'] = '^0.8.5';
 
-    // Move `ember-cli-htmlbars` into dependencies from devDependencies
-    contents.dependencies['ember-cli-htmlbars'] = contents.devDependencies['ember-cli-htmlbars'];
-    delete contents.devDependencies['ember-cli-htmlbars'];
-
     return stringifyAndNormalize(sortPackageJson(contents));
   },
 


### PR DESCRIPTION
Spinning up a new engine that was generated using this blueprint throws because of this.