### PR TITLE
Resolve lint errors

### DIFF
--- a/files/routable-files/addon-config/environment.js
+++ b/files/routable-files/addon-config/environment.js
@@ -1,10 +1,9 @@
-/* eslint-env node */
 'use strict';
 
-module.exports = function(environment) {
+module.exports = function (environment) {
   let ENV = {
     modulePrefix: '<%= engineModulePrefix %>',
-    environment
+    environment,
   };
 
   return ENV;

--- a/files/routable-files/addon/engine.js
+++ b/files/routable-files/addon/engine.js
@@ -7,7 +7,7 @@ const { modulePrefix } = config;
 
 const Eng = Engine.extend({
   modulePrefix,
-  Resolver
+  Resolver,
 });
 
 loadInitializers(Eng, modulePrefix);

--- a/files/routable-files/addon/routes.js
+++ b/files/routable-files/addon/routes.js
@@ -1,5 +1,5 @@
 import buildRoutes from 'ember-engines/routes';
 
-export default buildRoutes(function() {
+export default buildRoutes(function () {
   // Define your engine's route map here
 });

--- a/files/routable-files/index.js
+++ b/files/routable-files/index.js
@@ -1,13 +1,12 @@
-/* eslint-env node */
 'use strict';
 
-const EngineAddon = require('ember-engines/lib/engine-addon');
+const { buildEngine } = require('ember-engines/lib/engine-addon');
 
-module.exports = EngineAddon.extend({
+module.exports = buildEngine({
   name: '<%= dasherizedModuleName %>',
 
   lazyLoading: {
     enabled: <%= isLazy %>,
-    includeRoutesInApplication: <%= includeRoutesInApplication %>
-  }
+    includeRoutesInApplication: <%= includeRoutesInApplication %>,
+  },
 });

--- a/files/routeless-files/addon-config/environment.js
+++ b/files/routeless-files/addon-config/environment.js
@@ -1,10 +1,9 @@
-/* eslint-env node */
 'use strict';
 
-module.exports = function(environment) {
+module.exports = function (environment) {
   let ENV = {
     modulePrefix: '<%= engineModulePrefix %>',
-    environment
+    environment,
   };
 
   return ENV;

--- a/files/routeless-files/addon/engine.js
+++ b/files/routeless-files/addon/engine.js
@@ -7,7 +7,7 @@ const { modulePrefix } = config;
 
 const Eng = Engine.extend({
   modulePrefix,
-  Resolver
+  Resolver,
 });
 
 loadInitializers(Eng, modulePrefix);

--- a/files/routeless-files/index.js
+++ b/files/routeless-files/index.js
@@ -1,13 +1,12 @@
-/* eslint-env node */
 'use strict';
 
-const EngineAddon = require('ember-engines/lib/engine-addon');
+const { buildEngine } = require('ember-engines/lib/engine-addon');
 
-module.exports = EngineAddon.extend({
+module.exports = buildEngine({
   name: '<%= dasherizedModuleName %>',
 
   lazyLoading: {
     enabled: <%= isLazy %>,
-    includeRoutesInApplication: <%= includeRoutesInApplication %>
-  }
+    includeRoutesInApplication: <%= includeRoutesInApplication %>,
+  },
 });

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ const stringifyAndNormalizePath = require.resolve('ember-cli/lib/utilities/strin
 });
 const stringifyAndNormalize = require(stringifyAndNormalizePath);
 
+const EMBER_ENGINES_VERSION = '^0.8.13';
+
 module.exports = Object.assign({}, Addon, {
   description: 'Creates a stand-alone Engine for Ember.js.',
 
@@ -120,7 +122,11 @@ module.exports = Object.assign({}, Addon, {
     contents = JSON.parse(contents)
 
     // Add `ember-engines` to devDependencies by default
-    contents.devDependencies['ember-engines'] = '^0.8.12';
+    contents.devDependencies['ember-engines'] = EMBER_ENGINES_VERSION;
+
+    // Add `ember-engines` to peerDependencies by default
+    contents.peerDependencies = contents.peerDependencies || {};
+    contents.peerDependencies['ember-engines'] = EMBER_ENGINES_VERSION;
 
     return stringifyAndNormalize(sortPackageJson(contents));
   },


### PR DESCRIPTION
Resolves all lint errors that occur when running `yarn lint:js` in a freshly generated engine.

Also adds `ember-engines` as a peer dependency (also resolves the `node/no-unpublished-require` lint error).