### PR TITLE
Modernize blueprint and update ember-engines version

### DIFF
--- a/files/routable-files/index.js
+++ b/files/routable-files/index.js
@@ -6,8 +6,11 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
   name: '<%= dasherizedModuleName %>',
 
-  lazyLoading: {
-    enabled: <%= isLazy %>,
-    includeRoutesInApplication: <%= includeRoutesInApplication %>
+  lazyLoading: Object.freeze({
+    enabled: <%= isLazy %>
+  }),
+
+  isDevelopingAddon() {
+    return true;
   }
 });

--- a/files/routeless-files/index.js
+++ b/files/routeless-files/index.js
@@ -6,8 +6,11 @@ const EngineAddon = require('ember-engines/lib/engine-addon');
 module.exports = EngineAddon.extend({
   name: '<%= dasherizedModuleName %>',
 
-  lazyLoading: {
-    enabled: <%= isLazy %>,
-    includeRoutesInApplication: <%= includeRoutesInApplication %>
+  lazyLoading: Object.freeze({
+    enabled: <%= isLazy %>
+  }),
+
+  isDevelopingAddon() {
+    return true;
   }
 });

--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ module.exports = Object.assign({}, Addon, {
     contents = JSON.parse(contents)
 
     // Add `ember-engines` to devDependencies by default
-    contents.devDependencies['ember-engines'] = '^0.8.12';
+    contents.devDependencies['ember-engines'] = '^0.8.16';
 
     return stringifyAndNormalize(sortPackageJson(contents));
   },


### PR DESCRIPTION
This PR's modernize engine blueprint with the main package and keep the package up-to-date with the ember-engines version. 

cc: @dgeb @rwjblue 